### PR TITLE
TypeError: Unable to get property 'type' of undefined or null reference

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2511,7 +2511,7 @@ CKEDITOR.dom.range = function( root ) {
 			function nextDFS( node, childOnly ) {
 				var next;
 
-				if ( node.type == CKEDITOR.NODE_ELEMENT && node.isEditable( false ) )
+				if ( node && node.type == CKEDITOR.NODE_ELEMENT && node.isEditable( false ) )
 					next = node[ isMoveToEnd ? 'getLast' : 'getFirst' ]( notIgnoredEval );
 
 				if ( !childOnly && !next )
@@ -2521,7 +2521,7 @@ CKEDITOR.dom.range = function( root ) {
 			}
 
 			// Handle non-editable element e.g. HR.
-			if ( el.type == CKEDITOR.NODE_ELEMENT && !el.isEditable( false ) ) {
+			if ( el && el.type == CKEDITOR.NODE_ELEMENT && !el.isEditable( false ) ) {
 				this.moveToPosition( el, isMoveToEnd ? CKEDITOR.POSITION_AFTER_END : CKEDITOR.POSITION_BEFORE_START );
 				return true;
 			}


### PR DESCRIPTION
## Bug fix

System.Exception: JS Error [e1dcee36-6c96-410d-8652-237e8bea87d3]: 
ErrorMessage: TypeError: Unable to get property 'type' of undefined or null reference , href: http://ais/Engagement/Details/EngagementTabs/1044?activeTabId=processworkingpaper#, CallStack: TypeError: Unable to get property 'type' of undefined or null reference
   at CKEDITOR.dom.range.prototype.moveToElementEditablePosition (http://ais/Scripts/ckeditor/ckeditor.js:170:360)
   at CKEDITOR.dom.range.prototype.moveToElementEditEnd (http://ais/Scripts/ckeditor/ckeditor.js:174:34)
   at Anonymous function (http://ais/Scripts/ckeditor/ckeditor.js:947:45)
   at h (http://ais/Scripts/ckeditor/ckeditor.js:11:138)
   at Anonymous function (http://ais/Scripts/ckeditor/ckeditor.js:12:489)
   at CKEDITOR.editor.prototype.fire (http://ais/Scripts/ckeditor/ckeditor.js:14:130)
   at d (http://ais/Scripts/ckeditor/ckeditor.js:229:38)
   at h (http://ais/Scripts/ckeditor/ckeditor.js:11:138)
   at Anonymous function (http://ais/Scripts/ckeditor/ckeditor.js:12:489)
   at Anonymous function (http://ais/Scripts/ckeditor/ckeditor.js:58:394)
